### PR TITLE
Add a 'test redirect' link to redirect admin.

### DIFF
--- a/redirects/admin.py
+++ b/redirects/admin.py
@@ -1,9 +1,16 @@
 from django.contrib import admin
+from django.utils.html import escape
 from .models import Redirect
 
 
+@admin.register(Redirect)
 class RedirectAdmin(admin.ModelAdmin):
-    list_display = ('old_path', 'new_path')
+    list_display = ('old_path', 'new_path', 'test_redirect')
     search_fields = ('old_path', 'new_path')
 
-admin.site.register(Redirect, RedirectAdmin)
+    def test_redirect(self, obj):
+        return '<a target="_blank" href="{}">Test</a>'.format(
+            escape(obj.old_path)
+        )
+
+    test_redirect.allow_tags = True


### PR DESCRIPTION
This will allow quick testing of redirects; primarily, to ensure that the destination path exists, as well as ensuring that there are no configuration problems.

Minor stylistic change in here as well: use decorator form of `admin.register`.
